### PR TITLE
docs: add CONTRIBUTING.md and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,62 @@
+# Agentic Coding Guide
+
+This file provides guidance for AI coding agents working in this repository.
+
+## Repository Purpose
+
+`release-chrome-extension` is a GitHub Action that publishes a Chrome extension to the Chrome Web Store using the Chrome Web Store API with OAuth2 authentication.
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile   # install dependencies
+pnpm lint                        # lint with Biome (CI mode, no auto-fix)
+pnpm lint:fix                    # lint with auto-fix
+pnpm build                       # compile TypeScript → dist/index.js
+pnpm package                     # copy action.yml + README.md into dist/
+```
+
+> ℹ️ There is no automated test suite in this repository. Verify behaviour manually or with integration tests against the Chrome Web Store API.
+
+## Project Layout
+
+```
+src/
+  index.ts    # action entry point: reads inputs, calls CWS API, handles errors
+  cws.ts      # Chrome Web Store API client (upload, publish, status polling)
+oauth-mock-app/
+  server.mjs  # local OAuth2 mock server for obtaining a refresh token during development
+action.yml    # action metadata: inputs, outputs, runs.using: node24
+biome.json    # linter/formatter config
+```
+
+## Architecture
+
+The action flow is:
+
+1. Read `extension-id`, `extension-path`, and OAuth2 credentials from action inputs.
+2. Use `cws.ts` to upload the new extension zip to the Web Store draft.
+3. Publish the uploaded version.
+
+`cws.ts` wraps the Google APIs client (`googleapis`) for the Chrome Web Store. OAuth2 tokens are constructed from the provided client ID, client secret, and refresh token.
+
+### Getting OAuth2 credentials locally
+
+Use the included mock OAuth2 app to obtain a refresh token without a real OAuth2 client:
+
+```console
+node oauth-mock-app/server.mjs
+```
+
+Then follow the printed instructions in your browser.
+
+## Conventions
+
+- **TypeScript strict mode** — all types must be explicit; avoid `any`.
+- **Linter:** Biome — run `pnpm lint` before committing. `useLiteralKeys` and `noUselessElse` rules are disabled.
+- **Formatter:** Biome with space indentation.
+- **Node.js ≥ 24** is required.
+- **Conventional Commits** are required for all commits (`feat:`, `fix:`, `chore:`, etc.).
+- **Never commit `dist/`** — it is built by CI and deployed to the `latest` branch on release.
+- **Never commit OAuth2 credentials** — always use GitHub Actions secrets.
+- The `action.yml` `main` field points to `index.js` inside `dist/`, not the TypeScript source.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,74 @@
+# Contributing to release-chrome-extension
+
+Thank you for your interest in contributing!
+
+## Development Setup
+
+**Prerequisites:** Node.js ≥ 24, [pnpm](https://pnpm.io/)
+
+```bash
+# Install dependencies
+pnpm install
+```
+
+## Development Workflow
+
+```bash
+# Lint (CI mode, no auto-fix)
+pnpm lint
+
+# Lint with auto-fix
+pnpm lint:fix
+
+# Run unit tests
+pnpm test
+
+# Run tests with verbose output
+pnpm test -- --reporter=verbose
+
+# Run a single test file
+npx vitest run __test__/<file>.test.ts
+
+# Build (compiles TypeScript → dist/index.js via @vercel/ncc)
+pnpm build
+
+# Package (copies action.yml + README.md into dist/)
+pnpm package
+```
+
+## OAuth2 Credentials for Local Testing
+
+To test against the Chrome Web Store API, you need OAuth2 credentials (`oauth-client-id`, `oauth-client-secret`, `oauth-refresh-token`). A mock OAuth2 application is included for obtaining a refresh token locally:
+
+```console
+node oauth-mock-app/server.mjs
+```
+
+See the [Chrome Web Store API documentation](https://developer.chrome.com/webstore/using_webstore_api#beforeyoubegin) for full setup instructions.
+
+## Submitting Changes
+
+1. Fork the repository and create a branch from `master`.
+2. Make your changes with tests where applicable.
+3. Run `pnpm lint` and `pnpm test` to verify everything passes.
+4. Open a pull request against `master`.
+
+**Important:** All commit messages must follow [Conventional Commits][] — this is required for the automated release process to correctly determine version bumps and generate changelog entries.
+
+Examples:
+- `fix: handle API error responses from the Web Store`
+- `feat: support dry-run mode`
+- `chore: update dependencies`
+
+## Release Process
+
+Releases are automated with [Release Please](https://github.com/googleapis/release-please):
+
+1. Merge changes to `master` following Conventional Commits.
+2. Release Please opens or updates a release PR with version bumps and changelog updates.
+3. Squash and merge the release PR.
+4. CI builds `dist/`, pushes it to the `latest` branch, and creates signed `vX` and `vX.Y.Z` tags.
+
+> **Note:** Never commit generated `dist/` files to the source branch — they are built and published automatically by CI.
+
+[Conventional Commits]: https://www.conventionalcommits.org/en/v1.0.0/

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ All supported outputs are the following:
 | `oauth-client-secret` | The OAuth2 client secret.           | Yes      |
 | `oauth-refresh-token` | The OAuth2 refresh token.           | Yes      |
 
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, workflow, and release process.
+
 ## License
 
 [MIT](LICENSE)


### PR DESCRIPTION
## Summary

This PR adds two documentation files to help both human contributors and AI coding agents:

- **`CONTRIBUTING.md`** — development setup, workflow commands (`lint`, `test`, `build`, `package`), code style (Biome), PR guidelines, Conventional Commits requirement, and the release process. The README's inline contributing/release section is replaced with a link to this file.
- **`AGENTS.md`** — agentic coding guide covering commands cheatsheet, project layout, architecture overview, testing guidance, and key conventions (never commit `dist/`, strict TypeScript, etc.).