### PR TITLE
fix: update Node.js runtime to v24 LTS

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,5 +20,5 @@ inputs:
     required: true
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'index.js'

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "lint:fix": "biome check --write ."
   },
   "engines": {
-    "node": "20.1.0"
+    "node": ">=24.0.0"
   }
 }


### PR DESCRIPTION
Update the Node.js runtime from `node20` to `node24` (latest LTS).

## Changes
- `action.yml`: `runs.using` updated to `node24`
- `package.json`: `engines.node` updated to `>=24.0.0`

Node.js 20 reaches end-of-life on April 30, 2026. Node.js 24 became LTS in October 2025 and is supported until April 2028.